### PR TITLE
fixed typo in package name pramid -> pyramid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
         raise RuntimeError('Unable to determine version.')
 
 setup(
-    name='Pramid-Straw',
+    name='pyramid_straw',
     version=version,
     url='http://github.com/dz0ny/pyramid_straw/',
     license='MIT',


### PR DESCRIPTION
Wasn't able  to install it as a package because of name issue. The project name is `pyramid_straw` but the package name was `Pramid-Straw`, it's a good practice to follow single namespace for package name and project name.